### PR TITLE
Fix a TypeError fetching the allowed_methods when the ModelViewSet has no prefix in the callback (when is the class instance).

### DIFF
--- a/rest_framework_docs/api_endpoint.py
+++ b/rest_framework_docs/api_endpoint.py
@@ -47,8 +47,10 @@ class ApiEndpoint(object):
 
     def __get_allowed_methods__(self):
         callback_cls = self.callback.cls
-        return sorted([force_str(m).upper() for m in callback_cls.http_method_names if hasattr(callback_cls, m) or
-                       (issubclass(callback_cls, ModelViewSet) and m in VIEWSET_METHODS.get(self.callback.suffix))])
+        return sorted(
+            [force_str(m).upper() for m in callback_cls.http_method_names
+             if hasattr(callback_cls, m) or (issubclass(callback_cls, ModelViewSet)
+             and m in VIEWSET_METHODS.get(self.callback.suffix, ''))])
 
     def __get_docstring__(self):
         return inspect.getdoc(self.callback)


### PR DESCRIPTION
This commit is a fix https://github.com/debnet/django-rest-framework-docs/commit/85ba4d2623a45a336623c6862bbaa1937704d923

But also introduces a new `TypeError` when the `self.callback.suffix` is empty.
